### PR TITLE
Remove double close issue section

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -25,7 +25,4 @@ Add any other context or code blocks about the feature request here.
 
 # How can this issue be closed?
 
-
-# How can this issue be closed?
-
 Identify people related to this discussion, appropriate tags, and projects in the group org.


### PR DESCRIPTION
One of the commit suggestions in #4 created two sections on `How to close this issue` in the feature template. This PR removes the redundant section.