### PR TITLE
Add arfc.github.io pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Summary of changes
+<!--- In one or more sentences, describe the PR you are submitting. -->
+
+
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] I have read the **CONTRIBUTING** document.
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.
+
+## Associated Issues and PRs
+<!--- Please note any issues or pull requests associated with this pull request. -->
+
+- Issue: #
+
+
+## Associated Developers
+<!--- Please mention any developers who should be alerted of this PR. -->
+
+- Dev: @
+
+
+## Checklist for Reviewers
+
+Reviewers should use [this link](https://arfc.github.io/manual/guides/pull_requests) to get to the
+Review Checklist before they begin their review.


### PR DESCRIPTION
This PR adds the existing template for pull requests to the whole organization. 

It is unaltered, and closes #6.