### PR TITLE
Spelling mistake in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ Steps to reproduce the behavior (ideally as a minimum example of where the failu
 ## What inputs and outputs are involved?
 
 If applicable, add what you ran or received to help explain your problem.
-If there are relavent configuration files, please provide those as well.
+If there are relevant configuration files, please provide those as well.
 
 ## Are there additional replication details?
 


### PR DESCRIPTION
## Summary of changes
<!--- In one or more sentences, describe the PR you are submitting. -->

There was a typo in the bug issue template that was bothering me. Someone (I can't imagine who) misspelled `relevant`.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Associated Issues and PRs
<!--- Please note any issues or pull requests associated with this pull request. -->

- Issue: n/a


## Associated Developers
<!--- Please mention any developers who should be alerted of this PR. -->

- Dev: n/a


## Checklist for Reviewers

Reviewers should use [this link](https://arfc.github.io/manual/guides/pull_requests) to get to the
Review Checklist before they begin their review.
